### PR TITLE
Temporarily disable POST to CL 

### DIFF
--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -190,5 +190,5 @@ def handler(event, context):  # pylint: disable=unused-argument
     domain_verdict = get_valid_domain_verdict(email)
     if domain_verdict != "PASS":
         return validation_domain_failure(email, receipt, domain_verdict)
-
-    return send_to_court_listener(email, receipt)
+    # Temporarily disable POST to CL while fixing fetching free documents
+    # return send_to_court_listener(email, receipt)

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -179,9 +179,11 @@ def test_success(
         pacer_event_two,
         pacer_event_three,
     ]:
-        response = app.handler(event, "")
-        data = json.loads(response["body"])
+        # Temporarily disable POST to CL while fixing fetching free documents
+        pass
+        # response = app.handler(event, "")
+        # data = json.loads(response["body"])
 
-        assert response["statusCode"] == 200
-        assert "mail" in data
-        assert "receipt" in data
+        # assert response["statusCode"] == 200
+        # assert "mail" in data
+        # assert "receipt" in data


### PR DESCRIPTION
Disabled `send_to_court_listener` function while fixing fetching free documents in CL