### PR TITLE
9 Fix txs court mapping to txsd, retries and requests timeout

### DIFF
--- a/cl/env.json
+++ b/cl/env.json
@@ -1,6 +1,7 @@
 {
   "RecapEmailFunction": {
     "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",
-    "AUTH_TOKEN": "****************************"
+    "AUTH_TOKEN": "****************************",
+    "SENTRY_DSN": ""
   }
 }

--- a/cl/events/ses.json
+++ b/cl/events/ses.json
@@ -7,7 +7,7 @@
         "mail": {
           "timestamp": "2019-08-05T21:30:02.028Z",
           "source": "prvs=144d0cba7=sender@example.com",
-          "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
+          "messageId": "1u6oou7m4gpsu5u6qu8efj5dc20jtafff365uo81",
           "destination": [
             "recipient@example.com"
           ],
@@ -133,7 +133,7 @@
           "commonHeaders": {
             "returnPath": "prvs=144d0cba7=sender@example.com",
             "from": [
-              "\"Doe, John\" <sender@example.com>"
+              "\"Doe, John\" <DCECF_LiveDB@txs.uscourts.gov>"
             ],
             "date": "Mon, 5 Aug 2019 21:29:57 +0000",
             "to": [

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -4,6 +4,7 @@ pacer_to_cl_ids = {
     "cofc": "uscfc",  # Court of Federal Claims
     "neb": "nebraskab",  # Nebraska Bankruptcy
     "nysb-mega": "nysb",  # Remove the mega thing
+    "txs": "txsd",  # Southern District Of Texas
 }
 
 # Reverse dict of pacer_to_cl_ids

--- a/cl/recap_email/requirements.txt
+++ b/cl/recap_email/requirements.txt
@@ -1,3 +1,3 @@
 requests
-pyhumps
+pyhumps==3.7.2
 sentry-sdk

--- a/cl/template.yaml
+++ b/cl/template.yaml
@@ -20,6 +20,8 @@ Resources:
       Environment:
         Variables:
           RECAP_EMAIL_ENDPOINT: https://www.courtlistener.com/api/rest/v3/recap-email/
+          AUTH_TOKEN: xxxxxxxxxxxxxxxxxxxxxxx
+          SENTRY_DSN: ""
       Events:
         RecapEmail:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api

--- a/cl/tests/requirements.txt
+++ b/cl/tests/requirements.txt
@@ -3,7 +3,7 @@ pytest-mock
 boto3
 requests
 requests_mock
-pyhumps
+pyhumps==3.7.2
 flake8
 pylint
 mypy

--- a/cl/tests/requirements.txt
+++ b/cl/tests/requirements.txt
@@ -10,3 +10,4 @@ mypy
 types-requests
 pylint
 pylint-json2html
+sentry-sdk


### PR DESCRIPTION
According to the findings in #9, I've applied the following changes here:

`txs` court_id is now mapped to `txsd` before sending to CL, according to the evidence added here: https://github.com/freelawproject/awscloud/issues/9#issuecomment-1276837868

Fix retries, now the following HTTP response errors are going to be retried using the `retry` decorator:
`502 Bad Gateway, 503 Service Unavailable, 504 Gateway Timeout`
Other HTTP error status codes returned by the API are not going to be retried.

Every event now is going to be tried 3 times. The first try, 5 seconds later, and then 15 seconds later (10 seconds due to backoff + a delay of 5 seconds).

Added a timeout of 5 seconds to the POST request.

I reviewed the metrics for the lambda function on average an event can last 500ms:

- 2940 events between 0 to 1 second
- 65 events between 1 to 5 seconds
- 19 events between 5 to 10 seconds
- 19 events between 10 to 20 seconds
- 17 events between 20 to 50 seconds
- 8 events between 100 to 125 seconds
- 3 events of 650 seconds

![Screen Shot 2022-10-13 at 18 20 36](https://user-images.githubusercontent.com/486004/195728202-b9358eca-8bbe-427b-ac30-4a07d79b744a.png)

That's why I think a timeout of `5` seconds it's a reasonable value so in case of an event last more than that it will be retried instead of waiting more time for a response.

I downgraded pyhumps to 3.7.2 because seems that in the last version they changed the module name or something so now mypy throws an error when checking the imports. Hopefully, it'll be solved in the next version so we can use the last version again.
