### PR TITLE
11 Increase lambda requests retries

### DIFF
--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -135,9 +135,9 @@ def get_cl_court_id(email):
 
 @retry(
     (RequestsConnectionError, HTTPError, Timeout),
-    tries=3,
-    delay=5,
-    backoff=2,
+    tries=5,
+    delay=10,
+    backoff=3,
 )
 def send_to_court_listener(email, receipt):
     print(f"{get_combined_log_message(email)} sending to Court Listener API.")


### PR DESCRIPTION
According to #11 I have increased retries to 5, adding an initial delay of 10 and a backoff of 3.

With this setup request attempts will look like this:

1° original event
2° Retrying in 10 seconds
2° Retrying in 30 seconds
2° Retrying in 90 seconds
2° Retrying in 270 seconds

For a total of 400 seconds (6.6 minutes) before giving up.

Let me know what you think, I'll deploy it once it's merged.


