### PR TITLE
13 Fixes index error when parsing an invalid return path email address

### DIFF
--- a/cl/events/ses-invalid-return-path.json
+++ b/cl/events/ses-invalid-return-path.json
@@ -1,0 +1,79 @@
+{
+  "Records": [
+    {
+      "eventSource": "aws:ses",
+      "eventVersion": "1.0",
+      "ses": {
+        "mail": {
+          "timestamp": "2021-06-28T20:59:55.682Z",
+          "source": "test@example.com",
+          "messageId": "171jjm4scn8vgcn5vrcv4su427obcred7bekus81",
+          "destination": [
+            "test@recap.email"
+          ],
+          "headersTruncated": false,
+          "headers": [
+            {
+              "name": "Return-Path",
+              "value": "<>"
+            },
+            {
+              "name": "Received",
+              "value": "from mail-oi1-f227.google.com (mail-oi1-f227.google.com [209.85.167.227]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id 171jjm4scn8vgcn5vrcv4su427obcred7bekus81 for pacer@whlawpartners.business; Mon, 28 Jun 2021 20:59:55 +0000 (UTC)"
+            },
+            {
+              "name": "X-SES-Spam-Verdict",
+              "value": "PASS"
+            },
+            {
+              "name": "X-SES-Virus-Verdict",
+              "value": "PASS"
+            },
+            {
+              "name": "Received-SPF",
+              "value": "none (spfCheck: 209.85.167.227 is neither permitted nor denied by domain of whlawpartners.com) client-ip=209.85.167.227; envelope-from=edgar@whlawpartners.com; helo=mail-oi1-f227.google.com;"
+            }
+          ],
+          "commonHeaders": {
+            "from": [
+              "test@example.com"
+            ],
+            "date": "Mon, 28 Jun 2021 15:59:50 -0500",
+            "to": [
+              "test@recap.email"
+            ],
+            "messageId": "<142e01d76c60$8a2045b0$9e60d110$@whlawpartners.com>",
+            "subject": "FW: 21-2365 Steson Skender v. Eden Isle Corporation, et al \"Corporate Disclosure Statement\""
+          }
+        },
+        "receipt": {
+          "timestamp": "2021-06-28T20:59:55.682Z",
+          "processingTimeMillis": 841,
+          "recipients": [
+            "test@recap.email"
+          ],
+          "spamVerdict": {
+            "status": "PASS"
+          },
+          "virusVerdict": {
+            "status": "PASS"
+          },
+          "spfVerdict": {
+            "status": "GRAY"
+          },
+          "dkimVerdict": {
+            "status": "PASS"
+          },
+          "dmarcVerdict": {
+            "status": "GRAY"
+          },
+          "action": {
+            "type": "Lambda",
+            "functionArn": "arn:aws:lambda:us-east-1:383039475970:function:cl-RecapEmailFunction-v62QTUOf7qmQ",
+            "invocationType": "Event"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -72,7 +72,13 @@ def get_combined_log_message(email):
 
 def check_valid_domain(email_address):
     domain = email_address.lstrip("<").rstrip(">").split("@")
-    domain = domain[1]
+
+    try:
+        domain = domain[1]
+    except IndexError:
+        # Lack of @, invalid email address
+        return False
+
     tld_domain = domain.split(".")
 
     # Check if domain (tld_domain[-2]) and tld (tld_domain[-1]) match

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -127,6 +127,20 @@ def test_valid_domain_failed(valid_domain_failure_ses_event):
 
 
 @pytest.fixture()
+def invalid_return_path_ses_event():
+    with open("./events/ses-invalid-return-path.json") as file:
+        data = json.load(file)
+    return data
+
+
+def test_invalid_return_path(invalid_return_path_ses_event):
+    response = app.handler(invalid_return_path_ses_event, "")
+
+    assert response["statusCode"] == 424
+    assert response["valid_domain"]["status"] == "FAILED"
+
+
+@pytest.fixture()
 def ses_event():
     with open("./events/ses.json") as file:
         data = json.load(file)


### PR DESCRIPTION
This fixes #13, the error was triggered when receiving a notification with an invalid return path (no email address):

![Screen Shot 2023-01-11 at 12 55 00](https://user-images.githubusercontent.com/486004/211893627-88304b53-7898-4afd-8471-722b24d37447.png)

In order to solve it, in case of a return path email address lacks `@` like in an empty string or an invalid email address the `check_valid_domain` method will return `False`.

Let me know what you think.
