### PR TITLE
16 Added mow to pacer_to_cl_ids and implemented a logger to detect similar issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2-beta
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: isort Import Sorter
-        uses: isort/isort-action@v0.1.0
+        uses: isort/isort-action@v1
 
       - name: pylint Error Checker
         run: pylint --fail-under 9 -f colorized cl
@@ -36,7 +36,7 @@ jobs:
   lint-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v2
         with:
           python-version: "3.11"
@@ -50,7 +50,7 @@ jobs:
           pylint-json2html -f jsonextended -o pylint-report.html
 
       - name: Upload report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pylint report
           path: pylint-report.html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2-beta
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: cd cl && pip install -r recap_email/requirements.txt && pip install -r tests/requirements.txt
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2-beta
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: cd cl && pip install -r recap_email/requirements.txt && pip install -r tests/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11]
+        python-version: ["3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.10, 3.11]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,18 +21,18 @@ repos:
        args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/ikamensh/flynt/
-    rev: '0.76'
+    rev: '1.0.1'
     hooks:
      - id: flynt
        args: [--line-length=79, --transform-concats]
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 25.1.0
     hooks:
      - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 6.0.0
     hooks:
      - id: isort
        name: isort (python)

--- a/cl/events/pacer-2.json
+++ b/cl/events/pacer-2.json
@@ -161,9 +161,9 @@
                         }
                     ],
                     "commonHeaders": {
-                        "returnPath": "buttons@whlawpartners.com",
+                        "returnPath": "ecfMOW.notification@mow.uscourts.gov",
                         "from": [
-                            "Buttons McGee <buttons@whlawpartners.com>"
+                            "<ecfMOW.notification@mow.uscourts.gov>"
                         ],
                         "date": "Mon, 28 Jun 2021 13:51:08 -0500",
                         "to": [

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 
 import requests
@@ -139,6 +140,22 @@ def get_cl_court_id(email):
     return map_pacer_to_cl_id(sub_domain)
 
 
+def log_invalid_court_error(response):
+    """Checks if the response indicates an invalid court pk then send a report
+    to Sentry.
+    """
+    if response.status_code != 400:
+        return
+
+    for msg in response.json().get("court", []):
+        if "Invalid pk" in msg:
+            match = re.search(r'Invalid pk "([^"]+)"', msg)
+            if match:
+                error_message = f"Invalid court pk: {match.group(1)}"
+                sentry_sdk.capture_message(error_message, level="error")
+                break
+
+
 @retry(
     (RequestsConnectionError, HTTPError, Timeout),
     tries=5,
@@ -161,7 +178,7 @@ def send_to_court_listener(email, receipt):
         timeout=5,
         headers={
             "Content-Type": "application/json",
-            "Authorization": "Token " + os.getenv("AUTH_TOKEN"),
+            "Authorization": f"Token {os.getenv('AUTH_TOKEN')}",
         },
     )
 
@@ -169,6 +186,8 @@ def send_to_court_listener(email, receipt):
         # Raise an HTTPError for Bad Gateway, Service Unavailable or
         # Gateway Timeout status codes.
         court_listener_response.raise_for_status()
+
+    log_invalid_court_error(court_listener_response)
 
     print(
         f"Got {court_listener_response.status_code=} and content "

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -64,10 +64,9 @@ def get_combined_log_message(email):
         if header["name"] == "Subject":
             subject = header["value"]
 
-    return "Email with {subject}, from {source} to {destination}".format(
-        subject=subject,
-        source=email["source"],
-        destination=email["destination"],
+    return (
+        f"Email with {subject}, from {email['source']} to "
+        f"{email['destination']}"
     )
 
 
@@ -86,8 +85,7 @@ def check_valid_domain(email_address):
     # with uscourts and gov
     if tld_domain[-2] != "uscourts" and tld_domain[-1] != "gov":
         return False
-    else:
-        return True
+    return True
 
 
 def get_valid_domain_verdict(email):
@@ -229,7 +227,7 @@ def handler(event, context):  # pylint: disable=unused-argument
     )
     for test in gray_or_pass_tests:
         verdict = test(receipt)
-        if verdict != "PASS" and verdict != "GRAY":
+        if verdict not in {"PASS", "GRAY"}:
             return validation_failure(email, receipt, verdict)
 
     # Check domain is valid (comes from uscourts.gov)

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -5,6 +5,7 @@ pacer_to_cl_ids = {
     "neb": "nebraskab",  # Nebraska Bankruptcy
     "nysb-mega": "nysb",  # Remove the mega thing
     "txs": "txsd",  # Southern District Of Texas
+    "mow": "mowd",  # Western District of Missouri
 }
 
 # Reverse dict of pacer_to_cl_ids

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -19,5 +19,4 @@ def map_pacer_to_cl_id(pacer_id):
 def map_cl_to_pacer_id(cl_id):
     if cl_id == "nysb":
         return cl_id
-    else:
-        return cl_to_pacer_ids.get(cl_id, cl_id)
+    return cl_to_pacer_ids.get(cl_id, cl_id)

--- a/cl/recap_email/app/utils.py
+++ b/cl/recap_email/app/utils.py
@@ -31,7 +31,7 @@ def retry(
                 try:
                     return f(*args, **kwargs)
                 except ExceptionToCheck as e:
-                    msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
+                    msg = f"{str(e)}, Retrying in {mdelay} seconds..."
                     print(msg)
                     time.sleep(mdelay)
                     mtries -= 1

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -120,9 +120,10 @@ def test_get_cl_court_id_using_mapping():
             "common_headers": {"from": [f"ecfnotices@{pacer_id}.uscourts.gov"]}
         }
         result = app.get_cl_court_id(email)
-        assert (
-            result == expected_cl
-        ), f"For PACER id '{pacer_id}', expected CL id '{expected_cl}' but got '{result}'."
+        assert result == expected_cl, (
+            f"For PACER id '{pacer_id}', expected CL id '{expected_cl}' but "
+            f"got '{result}'."
+        )
 
 
 @pytest.fixture()
@@ -226,11 +227,13 @@ def test_success(
 @mock.patch.dict(
     os.environ,
     {
-        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501
         "AUTH_TOKEN": "************************",
     },
 )
-def test_request_court_field_actual_value(pacer_event_two, requests_mock):
+def test_request_court_field_actual_value(
+    pacer_event_two, requests_mock  # noqa: F811
+):
     """Confirm that the court_id in the request uses the right value
     from map_pacer_to_cl_id"""
     requests_mock.post(
@@ -252,11 +255,13 @@ def test_request_court_field_actual_value(pacer_event_two, requests_mock):
 @mock.patch.dict(
     os.environ,
     {
-        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501
         "AUTH_TOKEN": "************************",
     },
 )
-def test_report_request_for_invalid_court(pacer_event_one, requests_mock):
+def test_report_request_for_invalid_court(
+    pacer_event_one, requests_mock  # noqa: F811
+):
     """Confirm that if an invalid court_id is sent to CL, an error event is
     sent to Sentry."""
 

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -7,13 +7,16 @@ import pytest
 import requests  # noqa: F401
 import requests_mock  # noqa: F401
 from recap_email.app import app  # pylint: disable=import-error
-from recap_email.app.pacer import pacer_to_cl_ids
-from tests.unit.utils import MockResponse
+from recap_email.app.pacer import (  # pylint: disable=import-error
+    pacer_to_cl_ids,
+)
+
+from cl.tests.unit.utils import MockResponse
 
 
 @pytest.fixture()
 def spam_failure_ses_event():
-    with open("./events/ses-spam-failure.json") as file:
+    with open("./events/ses-spam-failure.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -29,7 +32,7 @@ def test_spam_failure(spam_failure_ses_event):
 
 @pytest.fixture()
 def virus_failure_ses_event():
-    with open("./events/ses-virus-failure.json") as file:
+    with open("./events/ses-virus-failure.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -45,7 +48,7 @@ def test_virus_failure(virus_failure_ses_event):
 
 @pytest.fixture()
 def spf_failure_ses_event():
-    with open("./events/ses-spf-failure.json") as file:
+    with open("./events/ses-spf-failure.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -61,7 +64,7 @@ def test_spf_failure(spf_failure_ses_event):
 
 @pytest.fixture()
 def dkim_failure_ses_event():
-    with open("./events/ses-dkim-failure.json") as file:
+    with open("./events/ses-dkim-failure.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -77,7 +80,7 @@ def test_dkim_failure(dkim_failure_ses_event):
 
 @pytest.fixture()
 def dmarc_failure_ses_event():
-    with open("./events/ses-dmarc-failure.json") as file:
+    with open("./events/ses-dmarc-failure.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -128,7 +131,9 @@ def test_get_cl_court_id_using_mapping():
 
 @pytest.fixture()
 def valid_domain_failure_ses_event():
-    with open("./events/ses-valid-domain-failure.json") as file:
+    with open(
+        "./events/ses-valid-domain-failure.json", encoding="utf-8"
+    ) as file:
         data = json.load(file)
     return data
 
@@ -142,7 +147,9 @@ def test_valid_domain_failed(valid_domain_failure_ses_event):
 
 @pytest.fixture()
 def invalid_return_path_ses_event():
-    with open("./events/ses-invalid-return-path.json") as file:
+    with open(
+        "./events/ses-invalid-return-path.json", encoding="utf-8"
+    ) as file:
         data = json.load(file)
     return data
 
@@ -156,35 +163,35 @@ def test_invalid_return_path(invalid_return_path_ses_event):
 
 @pytest.fixture()
 def ses_event():
-    with open("./events/ses.json") as file:
+    with open("./events/ses.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
 
 @pytest.fixture()
 def ses_gray_event():
-    with open("./events/ses-dkim-gray.json") as file:
+    with open("./events/ses-dkim-gray.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
 
 @pytest.fixture()
 def pacer_event_one():
-    with open("./events/pacer-1.json") as file:
+    with open("./events/pacer-1.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
 
 @pytest.fixture()
 def pacer_event_two():
-    with open("./events/pacer-2.json") as file:
+    with open("./events/pacer-2.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
 
 @pytest.fixture()
 def pacer_event_three():
-    with open("./events/pacer-3.json") as file:
+    with open("./events/pacer-3.json", encoding="utf-8") as file:
         data = json.load(file)
     return data
 
@@ -192,11 +199,11 @@ def pacer_event_three():
 @mock.patch.dict(
     os.environ,
     {
-        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501, pylint: disable=line-too-long
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
         "AUTH_TOKEN": "************************",
     },
 )
-def test_success(
+def test_success(  # pylint: disable=too-many-arguments
     ses_event,
     ses_gray_event,
     pacer_event_one,
@@ -227,7 +234,7 @@ def test_success(
 @mock.patch.dict(
     os.environ,
     {
-        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
         "AUTH_TOKEN": "************************",
     },
 )
@@ -255,7 +262,7 @@ def test_request_court_field_actual_value(
 @mock.patch.dict(
     os.environ,
     {
-        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
         "AUTH_TOKEN": "************************",
     },
 )

--- a/cl/tests/unit/utils.py
+++ b/cl/tests/unit/utils.py
@@ -1,4 +1,6 @@
-class MockResponse:
+class MockResponse:  # pylint: disable=too-few-public-methods
+    """A mock of a request Response object"""
+
     def __init__(self, status_code, json_data):
         self.status_code = status_code
         self._json_data = json_data

--- a/cl/tests/unit/utils.py
+++ b/cl/tests/unit/utils.py
@@ -1,5 +1,3 @@
-
-
 class MockResponse:
     def __init__(self, status_code, json_data):
         self.status_code = status_code

--- a/cl/tests/unit/utils.py
+++ b/cl/tests/unit/utils.py
@@ -1,0 +1,9 @@
+
+
+class MockResponse:
+    def __init__(self, status_code, json_data):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pre-commit==2.17.0
+pre-commit==4.1.0


### PR DESCRIPTION
This PR resolves #16 by adding `mow->mowd` to the `pacer_to_cl_ids` mapping.

Additionally, a method was added to send similar issues to Sentry. If an email is received indicating that CL returns an invalid court PK error, the issue is reported so we can take action and fix the problem by adding the required court mapping.

New related tests have been added for these changes.

The CI actions have also been updated, as they were no longer compatible with the GitHub environment. 
Additionally, related lint complaints were fixed to ensure they pass.

