### PR TITLE
Bump Lambda python Runtime to 3.11

### DIFF
--- a/cl/template.yaml
+++ b/cl/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       CodeUri: recap_email/
       Handler: app.app.handler
-      Runtime: python3.8
+      Runtime: python3.11
       Environment:
         Variables:
           RECAP_EMAIL_ENDPOINT: https://www.courtlistener.com/api/rest/v3/recap-email/


### PR DESCRIPTION
@mlissner while building the Lambda for its subsequent deployment using:

`sam build --use-container`

noticed that it was being built for Python 3.8. However, the AWS runtime for prod is Python 3.11:

![Screenshot 2025-03-17 at 10 18 53 a m](https://github.com/user-attachments/assets/7844fe4a-e8a1-4042-bd87-ea9bcfabf249)

It appears that the Lambda function is configured to automatically update the runtime version to the latest one:
![Screenshot 2025-03-17 at 10 19 49 a m](https://github.com/user-attachments/assets/0eab07cb-f789-473b-8165-8318cd3d3101)

In this PR, I updated the template to use Python 3.11, matching the production environment.
