### PR TITLE
19 Added more courts to pacer_to_cl_ids

### DIFF
--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -6,6 +6,8 @@ pacer_to_cl_ids = {
     "nysb-mega": "nysb",  # Remove the mega thing
     "txs": "txsd",  # Southern District Of Texas
     "mow": "mowd",  # Western District of Missouri
+    "gas": "gasd",  # Southern District of Georgia
+    "cfc": "uscfc",  # Court of Federal Claims
 }
 
 # Reverse dict of pacer_to_cl_ids

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -289,5 +289,8 @@ def test_report_request_for_invalid_court(
         )
         app.handler(pacer_event_one, "")
     # The expected error message should be sent to Sentry.
-    expected_error = "Invalid court pk: whla"
+    expected_error = (
+        "Invalid court pk: whla - "
+        "message_id: 171jjm4scn8vgcn5vrcv4su427obcred7bekus81"
+    )
     mock_sentry_capture.assert_called_with(expected_error, level="error")


### PR DESCRIPTION
This PR fixes #19 by adding `gas` to the PACER mapping so it redirects to `gasd`.

I also added `cfc -> uscfc`. Based on the examples we received, we only have announcements emails from this court. I confirmed that these emails will be ignored during processing, so it's fine to send them to CL in case we receive a valid NEF from this court in the future.

Additionally, improved log messages to make it easier to identify issues during investigations of failures or incorrect court IDs.

