### PR TITLE
chore: Move formatting and linting to Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,50 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
+      - uses: pre-commit/action@v3.0.1
+
       - name: Install dependencies
         run: cd cl && pip install -r recap_email/requirements.txt && pip install -r tests/requirements.txt
-
-      - name: Black Code Formatter
-        uses: psf/black@stable
-
-      - name: Run flake8
-        uses: suo/flake8-github-action@releases/v1
-        with:
-          checkName: 'lint'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: isort Import Sorter
-        uses: isort/isort-action@v1
-
-      - name: pylint Error Checker
-        run: pylint --fail-under 9 -f colorized cl
 
       - name: mypy Static Type Checker
         run: mypy --ignore-missing-imports .
-
-  lint-report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: cd cl && pip install -r recap_email/requirements.txt && pip install -r tests/requirements.txt
-
-      - name: pylint Generate Report
-        run: >
-          pylint --exit-zero --load-plugins=pylint_json2html -f jsonextended cl |
-          pylint-json2html -f jsonextended -o pylint-report.html
-
-      - name: Upload report
-        uses: actions/upload-artifact@v4
-        with:
-          name: pylint report
-          path: pylint-report.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: migrations
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v5.0.0
     hooks:
      - id: check-added-large-files
      - id: check-ast
@@ -20,28 +20,9 @@ repos:
      - id: trailing-whitespace
        args: [--markdown-linebreak-ext=md]
 
-  - repo: https://github.com/ikamensh/flynt/
-    rev: '1.0.1'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
     hooks:
-     - id: flynt
-       args: [--line-length=79, --transform-concats]
-
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-     - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.0
-    hooks:
-     - id: isort
-       name: isort (python)
-
-#
-# Tried and Failed
-#
-# 1. I tried doing mypy too, but it was a mess because it runs in its own
-#   isolated environment, that lacks all our dependencies.
-# 2. We might want flake8 someday. It's easy to turn on, but it's so noisy on
-#    our current code that it'd take some fine-tuning to get it right.
-# 3. semgrep was too slow and had to be moved to a github action.
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -81,11 +81,7 @@ def check_valid_domain(email_address):
 
     tld_domain = domain.split(".")
 
-    # Check if domain (tld_domain[-2]) and tld (tld_domain[-1]) match
-    # with uscourts and gov
-    if tld_domain[-2] != "uscourts" and tld_domain[-1] != "gov":
-        return False
-    return True
+    return tld_domain[-2:] == ["uscourts", "gov"]
 
 
 def get_valid_domain_verdict(email):

--- a/cl/tests/requirements.txt
+++ b/cl/tests/requirements.txt
@@ -4,10 +4,6 @@ boto3
 requests
 requests_mock
 pyhumps==3.7.2
-flake8
-pylint
 mypy
 types-requests
-pylint
-pylint-json2html
 sentry-sdk

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -239,7 +239,8 @@ def test_success(  # pylint: disable=too-many-arguments
     },
 )
 def test_request_court_field_actual_value(
-    pacer_event_two, requests_mock  # noqa: F811
+    pacer_event_two,
+    requests_mock,  # noqa: F811
 ):
     """Confirm that the court_id in the request uses the right value
     from map_pacer_to_cl_id"""
@@ -254,9 +255,9 @@ def test_request_court_field_actual_value(
     # Retrieve the request that made by send_to_court_listener
     request = requests_mock.request_history[0]
     body = json.loads(request.body)
-    assert (
-        body.get("court") == "mowd"
-    ), f"Expected 'mowd', but got '{body.get('court')}'"
+    assert body.get("court") == "mowd", (
+        f"Expected 'mowd', but got '{body.get('court')}'"
+    )
 
 
 @mock.patch.dict(
@@ -267,7 +268,8 @@ def test_request_court_field_actual_value(
     },
 )
 def test_report_request_for_invalid_court(
-    pacer_event_one, requests_mock  # noqa: F811
+    pacer_event_one,
+    requests_mock,  # noqa: F811
 ):
     """Confirm that if an invalid court_id is sent to CL, an error event is
     sent to Sentry."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,32 @@
-[tool.black]
+[tool.ruff]
 line-length = 79
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 79
-skip_glob = "*/migrations/*.py"
-
-[tool.pylint.messages_control]
-disable = "C0330, C0326"
-
-[tool.pylint.format]
-max-line-length = "79"
+lint.select = [
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # pycodestyle
+  "E",
+  # Pyflakes errors
+  "F",
+  # isort
+  "I",
+  # flake8-simplify
+  "SIM",
+  # flake8-tidy-imports
+  "TID",
+  # pyupgrade
+  "UP",
+  # Pyflakes warnings
+  "W",
+]
+lint.ignore = [
+  # flake8-bugbear opinionated rules
+  "B9",
+  # line-too-long
+  "E501",
+  # suppressible-exception
+  "SIM105",
+  # if-else-block-instead-of-if-exp
+  "SIM108",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,4 @@
-# Flake8 does not yet support pyproject.toml.
-# Issue: https://gitlab.com/pycqa/flake8/-/issues/428
-
-[flake8]
-max-line-length = 79
-extend-ignore = E203, W503
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,.eggs,.env,.venv
-
-# Neither does mypy, but this is in progress.
-# See:
-# - https://github.com/python/mypy/issues/5205
-# - https://github.com/python/mypy/pull/5208
+# Mypy configuration pending migration to pyproject.toml
 
 [mypy]
 warn_return_any = True


### PR DESCRIPTION
Replace Black, isort, and pylint with Ruff.

Another pull request like:
- https://github.com/freelawproject/seal-rookery/pull/38