### PR TITLE
chore(ci): Prevent duplicate GitHub Actions runs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Previously, workflows used this trigger:

```yaml
on: [push, pull_request]
```

This means run on every push and pull request, to any branch. This would lead to duplicate runs when creating a pull request, as the push to the branch would trigger the tests, then the pull request would trigger them again.

This PR migrates workflows so the `push` event is only triggered on the `main` branch. Compare with #21 to see that the duplicate runs are gone.