### PR TITLE
19 Ignore invalid subdomains that are not courts

### DIFF
--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -10,6 +10,8 @@ pacer_to_cl_ids = {
     "cfc": "uscfc",  # Court of Federal Claims
 }
 
+sub_domains_to_ignore = ["usdoj", "law", "psc", "updates", "MIWD"]
+
 # Reverse dict of pacer_to_cl_ids
 cl_to_pacer_ids = {v: k for k, v in pacer_to_cl_ids.items()}
 


### PR DESCRIPTION
I went through all the AWS `recap.email` Lambda issues on Sentry to check which courts were reported as invalid. I reviewed the related messages to determine whether we need to add them to the court mapping dictionary or if they can simply be ignored.

The subdomains found were:

- **usdoj (usdoj.gov):** Not a court, so we should ignore these messages.
- **law (law.nyc.gov):** Not a court, so we should ignore these messages.
- **psc (psc.uscourts.gov):** Not a court, so we should ignore these messages.
- **updates (updates.uscourts.gov):** Not a court, so we should ignore these messages.
- **MIWD (MIWD.USCOURTS.GOV):** This is the Western District of Michigan court, but in this case, the email address was in uppercase. The related message was a general announcement:

> Notice to all Western District of Michigan registered attorneys:
>  
> Attached for your reference is Administrative Order 25-MS-032 regarding the adoption of standard conditions of supervision, amending Administrative Order 17-MS-023.

It appears to be a manually sent email. This suggests that uppercase `MIWD` messages should also be ignored. So far, this is the only message we've received in this format. Other NEFs from lowercase `miwd` are working correctly.

For now, I've added `MIWD` to the list of subdomains to ignore.

Additionally, I updated the Sentry logger to prevent excessive issue creation. Using a fingerprint, related errors should now be grouped into a single issue.
