### PR TITLE
15 Included ACMS fedcourts.us domain in the domain whitelist

### DIFF
--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -81,7 +81,11 @@ def check_valid_domain(email_address):
 
     tld_domain = domain.split(".")
 
-    return tld_domain[-2:] == ["uscourts", "gov"]
+    valid_domains = [
+        ["uscourts", "gov"],
+        ["fedcourts", "us"],  # ACMS
+    ]
+    return tld_domain[-2:] in valid_domains
 
 
 def get_valid_domain_verdict(email):

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -111,6 +111,8 @@ def test_multiple_domains_success():
         "cacd_ecfmail@uscourts.gov",
         "cacd_ecfmail@cacd.test.uscourts.gov",
         "cacd_ecfmail@cacd.uscourts.gov",
+        "ACMS@ca9.fedcourts.us",
+        "ACMS@ca2.fedcourts.us",
     ]
 
     for email in valid_emails:


### PR DESCRIPTION
This PR fixes #15.

Now that we have completed support for ACMS NDA notifications in [juriscraper#1311](https://github.com/freelawproject/juriscraper/issues/1311), [juriscraper#1510](https://github.com/freelawproject/juriscraper/pull/1510), and [courtlistener#5846](https://github.com/freelawproject/courtlistener/issues/5846), we can now start actually sending these ACMS notifications to CL by adding `fedcourts.us` domain in the domain whitelist.