### PR TITLE
28 Map court ID: id to idd in CL

### DIFF
--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -9,6 +9,7 @@ pacer_to_cl_ids = {
     "gas": "gasd",  # Southern District of Georgia
     "cfc": "uscfc",  # Court of Federal Claims
     "sc-us": "scotus",  # Supreme Court of the United States
+    "id": "idd",  # District Court, D. Idaho
 }
 
 sub_domains_to_ignore = ["usdoj", "law", "psc", "updates", "MIWD"]


### PR DESCRIPTION
This PR adds the required mapping from the email domain `id` to the court `idd` that corresponds to the District Court, D. Idaho.
Fixes: #28