### PR TITLE
Texas email routing

### DIFF
--- a/cl/env.json
+++ b/cl/env.json
@@ -2,6 +2,7 @@
   "RecapEmailFunction": {
     "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",
     "SCOTUS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/scrapers/scotus-email/",
+    "TEXAS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/state/tx/tames/alerts",
     "AUTH_TOKEN": "****************************",
     "SENTRY_DSN": ""
   }

--- a/cl/events/texas-1.json
+++ b/cl/events/texas-1.json
@@ -103,7 +103,7 @@
           "date": "Mon, 5 Aug 2019 21:29:57 +0000",
           "to": ["\"user@recap.email\" <user@recap.email>"],
           "messageId": "<F8098FDD-49A3-442D-9935-F6112B195BDA@txcourts.gov>",
-          "subject": "This is a test"
+          "subject": "Automated Case Update from First Court of Appeals"
         }
       },
       "receipt": {

--- a/cl/events/texas-1.json
+++ b/cl/events/texas-1.json
@@ -1,0 +1,136 @@
+{
+  "Records": [{
+    "eventSource": "aws:ses",
+    "eventVersion": "1.0",
+    "ses": {
+      "mail": {
+        "timestamp": "2019-08-05T21:30:02.028Z",
+        "source": "prvs=144d0cba7=noreply-tames@txcourts.gov",
+        "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
+        "destination": ["user@recap.email"],
+        "headersTruncated": false,
+        "headers": [{
+          "name": "Return-Path",
+          "value": "<prvs=144d0cba7=noreply-tames@txcourts.gov>"
+        }, {
+          "name": "Received",
+          "value": "from smtp.txcourts.gov [203.0.113.0]) by inbound-smtp.us-east-1.amazonaws.com with SMTP id bsvpsoklfhu7u50iur7h0kk9a2ou0r7iexample for user@recap.email; Mon, 05 Aug 2019 21:30:02 +0000 (UTC)"
+        }, {
+          "name": "X-SES-Spam-Verdict",
+          "value": "PASS"
+        }, {
+          "name": "X-SES-Virus-Verdict",
+          "value": "PASS"
+        }, {
+          "name": "Received-SPF",
+          "value": "pass (spfCheck: domain of txcourts.gov designates 203.0.113.0 as permitted sender) client-ip=203.0.113.0; envelope-from=prvs=144d0cba42=noreply-tames@txcourts.gov; helo=smtp.txcourts.gov;"
+        }, {
+          "name": "Authentication-Results",
+          "value": "amazonses.com; spf=pass (spfCheck: domain of txcourts.gov designates 203.0.113.0 as permitted sender) client-ip=203.0.113.0; envelope-from=prvs=144d0cba42=noreply-tames@txcourts.gov; helo=smtp.txcourts.gov; dkim=pass header.i=@txcourts.gov;dmarc=none header.from=txcourts.gov;"
+        }, {
+          "name": "X-SES-RECEIPT",
+          "value": "AEFBQUFBQUFBQUFHbFo0VU81VzVuYmRDNm51nhTVWpabDh6J4V2l5cG5PSHFtNzlBeUk90example"
+        }, {
+          "name": "X-SES-DKIM-SIGNATURE",
+          "value": "a=rsa-sha256; q=dns/txt; b=Cm1emU30VcD6example=; c=relaxed/simple; s=6gbrjpgwjs5zn6fwqknexample; d=amazonses.com; t=1567719002; v=1; bh=DSofsjAoUvyZj6YsBDP5enpRO1otGb7Nes0Qexample=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;"
+        }, {
+          "name": "DKIM-Signature",
+          "value": "v=1; a=rsa-sha256; c=relaxed/relaxed; d=txcourts.gov; i=@txcourts.gov; q=dns/txt;s=example12345; t=1567719001; x=1599255001; h=from:to:subject:date:message-id:references:in-reply-to:mime-version; bh=sjAoUvyZj6YsBDP5enpRO1otGb7s0Qexample=;b=EQw2D4RLOW2IHE9OgfEA4WXp+AENJtaD2+63wmd5J+d+t/xoaiKUGClOS7WhpyOmlipryOz+iOhxUv350xJIHjLTi9Jsnlw76mRK8o4770TaUz620joCVN21n4cxsrRZpv+1kS0EcAxaF30pmwlni+XT4emsVxn7zO0I8example=;"
+        }, {
+          "name": "Received",
+          "value": "from mail.txcourts.gov (mail.txcourts.gov [203.0.113.0]) by email-inbound-relay-1d-9ec21598.us-east-1.txcourts.gov (Postfix) with ESMTPS id 57F83A2042 for<user@recap.email>; Mon, 5 Aug 2019 21:29:58 +0000 (UTC)"
+        }, {
+          "name": "From",
+          "value": "\"TAMES CaseMail\" <noreply-tames@txcourts.gov>"
+        }, {
+          "name": "To",
+          "value": "\"user@recap.email\" <user@recap.email>"
+        }, {
+          "name": "Subject",
+          "value": "This is a test"
+        }, {
+          "name": "Thread-Topic",
+          "value": "This is a test"
+        }, {
+          "name": "Thread-Index",
+          "value": "AQHVZDAaQ58yKI8q7kaAjkhC5stGexample"
+        }, {
+          "name": "Date",
+          "value": "Mon, 5 Aug 2019 21:29:57 +0000"
+        }, {
+          "name": "Message-ID",
+          "value": "<F8098FDD-49A3-442D-9935-F6112example@txcourts.gov>"
+        }, {
+          "name": "References",
+          "value": "<1FCED16B-F6B0-4506-A6F0-594DFexample@txcourts.gov>"
+        }, {
+          "name": "In-Reply-To",
+          "value": "<1FCED16B-F6B0-4506-A6F0-594DFexample@txcourts.gov>"
+        }, {
+          "name": "Accept-Language",
+          "value": "en-US"
+        }, {
+          "name": "Content-Language",
+          "value": "en-US"
+        }, {
+          "name": "X-MS-Has-Attach",
+          "value": ""
+        }, {
+          "name": "X-MS-TNEF-Correlator",
+          "value": ""
+        }, {
+          "name": "x-ms-exchange-messagesentrepresentingtype",
+          "value": "1"
+        }, {
+          "name": "x-ms-exchange-transport-fromentityheader",
+          "value": "Hosted"
+        }, {
+          "name": "x-originating-ip",
+          "value": "[203.0.113.0]"
+        }, {
+          "name": "Content-Type",
+          "value": "multipart/alternative; boundary=\"_000_F8098FDD49A344F6112B195BDAexamplecom_\""
+        }, {
+          "name": "MIME-Version",
+          "value": "1.0"
+        }, {
+          "name": "Precedence",
+          "value": "Bulk"
+        }],
+        "commonHeaders": {
+          "returnPath": "prvs=144d0cba7=noreply-tames@txcourts.gov",
+          "from": ["\"TAMES CaseMail\" <noreply-tames@txcourts.gov>"],
+          "date": "Mon, 5 Aug 2019 21:29:57 +0000",
+          "to": ["\"user@recap.email\" <user@recap.email>"],
+          "messageId": "<F8098FDD-49A3-442D-9935-F6112B195BDA@txcourts.gov>",
+          "subject": "This is a test"
+        }
+      },
+      "receipt": {
+        "timestamp": "2019-08-05T21:30:02.028Z",
+        "processingTimeMillis": 1205,
+        "recipients": ["user@recap.email"],
+        "spamVerdict": {
+          "status": "PASS"
+        },
+        "virusVerdict": {
+          "status": "PASS"
+        },
+        "spfVerdict": {
+          "status": "PASS"
+        },
+        "dkimVerdict": {
+          "status": "PASS"
+        },
+        "dmarcVerdict": {
+          "status": "GRAY"
+        },
+        "action": {
+          "type": "Lambda",
+          "functionArn": "arn:aws:lambda:us-east-1:123456789012:function:IncomingEmail",
+          "invocationType": "Event"
+        }
+      }
+    }
+  }]
+}

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -11,7 +11,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError, Timeout
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
-from .pacer import map_domain_to_cl_id, sub_domains_to_ignore
+from .pacer import map_email_to_cl_id, sub_domains_to_ignore
 from .utils import retry  # pylint: disable=import-error
 
 # NOTE - This is necessary for the relative imports.
@@ -144,9 +144,7 @@ def get_cl_court_id(email):
     :param email: The email dict from AWS
     :return the CL court ID (not the PACER ID)
     """
-    from_addr = email["common_headers"]["from"][0]
-    domain = parseaddr(from_addr)[1].split("@")[1]
-    return map_domain_to_cl_id(domain)
+    return map_email_to_cl_id(email)
 
 
 def log_invalid_court_error(response, message_id):

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -31,6 +31,7 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
 )
 
+RECAP_EMAIL_ENDPOINT = None
 CL_ENDPOINT_MAP = {}
 
 
@@ -240,14 +241,15 @@ def send_to_court_listener(email, receipt):
 
 
 def handler(event, context):  # pylint: disable=unused-argument
-    recap_email_endpoint = os.getenv("RECAP_EMAIL_ENDPOINT")
+    global RECAP_EMAIL_ENDPOINT
+    RECAP_EMAIL_ENDPOINT = os.getenv("RECAP_EMAIL_ENDPOINT")
     scotus_email_endpoint = os.getenv("SCOTUS_EMAIL_ENDPOINT")
     texas_email_endpoint = os.getenv("TEXAS_EMAIL_ENDPOINT")
     global CL_ENDPOINT_MAP
     CL_ENDPOINT_MAP = {
         "sc-us.gov": scotus_email_endpoint,
-        "fedcourts.us": recap_email_endpoint,
-        "uscourts.gov": recap_email_endpoint,
+        "fedcourts.us": RECAP_EMAIL_ENDPOINT,
+        "uscourts.gov": RECAP_EMAIL_ENDPOINT,
         "txcourts.gov": texas_email_endpoint,
     }
 

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -31,8 +31,8 @@ sentry_sdk.init(
     traces_sample_rate=1.0,
 )
 
-RECAP_EMAIL_ENDPOINT = None
-CL_ENDPOINT_MAP = {}
+RECAP_EMAIL_ENDPOINT: str = ""
+CL_ENDPOINT_MAP: dict[str, str] = {}
 
 
 def get_ses_email_headers(email, header_name):

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -1,3 +1,5 @@
+from email.utils import parseaddr
+
 pacer_to_cl_ids = {
     # Maps PACER ids to their CL equivalents
     "azb": "arb",  # Arizona Bankruptcy Court
@@ -27,16 +29,46 @@ def map_cl_to_pacer_id(cl_id):
     return cl_to_pacer_ids.get(cl_id, cl_id)
 
 
+def get_tx_court_id_from_subject(subject: str) -> str | None:
+    if not subject.startswith("Automated Case Update from"):
+        return None
+    return {
+        "First Court of Appeals": "txctapp1",
+        "Second Court of Appeals": "txctapp2",
+        "Third Court of Appeals": "txctapp3",
+        "Fourth Court of Appeals": "txctapp4",
+        "Fifth Court of Appeals": "txctapp5",
+        "Sixth Court of Appeals": "txctapp6",
+        "Seventh Court of Appeals": "txctapp7",
+        "Eighth Court of Appeals": "txctapp8",
+        "Ninth Court of Appeals": "txctapp9",
+        "Tenth Court of Appeals": "txctapp10",
+        "Eleventh Court of Appeals": "txctapp11",
+        "Twelfth Court of Appeals": "txctapp12",
+        "Thirteenth Court of Appeals": "txctapp13",
+        "Fourteenth Court of Appeals": "txctapp14",
+        "Fifteenth Court of Appeals": "txctapp15",
+        "Court of Criminal Appeals": "texcrimapp",
+        "Supreme Court": "tex",
+    }.get(subject[27:])
+
+
 domain_to_cl_id = {
     "sc-us.gov": "scotus",  # Supreme Court of the United States
     "txcourts.gov": "texas",  # All Texas courts
 }
 
 
-def map_domain_to_cl_id(full_domain: str):
+def map_email_to_cl_id(email):
+    from_addr = email["common_headers"]["from"][0]
+    full_domain = parseaddr(from_addr)[1].split("@")[1]
     parts = full_domain.split(".")
     domain = ".".join(parts[-2:])
     if domain in {"fedcourts.us", "uscourts.gov"}:
         return map_pacer_to_cl_id(parts[0])
-    print(domain_to_cl_id, full_domain)
-    return domain_to_cl_id.get(full_domain, full_domain)
+    maybe_cl_id = domain_to_cl_id.get(full_domain, full_domain)
+    if maybe_cl_id == "texas":
+        cl_id = get_tx_court_id_from_subject(email["commonHeaders"]["subject"])
+    else:
+        cl_id = maybe_cl_id
+    return cl_id

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -36,4 +36,5 @@ def map_domain_to_cl_id(full_domain: str):
     domain = ".".join(parts[-2:])
     if domain in { "fedcourts.us", "uscourts.gov" }:
         return map_pacer_to_cl_id(parts[0])
+    print(domain_to_cl_id, full_domain)
     return domain_to_cl_id.get(full_domain, full_domain)

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -34,7 +34,7 @@ domain_to_cl_id = {
 def map_domain_to_cl_id(full_domain: str):
     parts = full_domain.split(".")
     domain = ".".join(parts[-2:])
-    if domain in { "fedcourts.us", "uscourts.gov" }:
+    if domain in {"fedcourts.us", "uscourts.gov"}:
         return map_pacer_to_cl_id(parts[0])
     print(domain_to_cl_id, full_domain)
     return domain_to_cl_id.get(full_domain, full_domain)

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -8,7 +8,6 @@ pacer_to_cl_ids = {
     "mow": "mowd",  # Western District of Missouri
     "gas": "gasd",  # Southern District of Georgia
     "cfc": "uscfc",  # Court of Federal Claims
-    "sc-us": "scotus",  # Supreme Court of the United States
     "id": "idd",  # District Court, D. Idaho
 }
 
@@ -26,3 +25,15 @@ def map_cl_to_pacer_id(cl_id):
     if cl_id == "nysb":
         return cl_id
     return cl_to_pacer_ids.get(cl_id, cl_id)
+
+domain_to_cl_id = {
+    "sc-us.gov": "scotus",  # Supreme Court of the United States
+    "txcourts.gov": "texas",  # All Texas courts
+}
+
+def map_domain_to_cl_id(full_domain: str):
+    parts = full_domain.split(".")
+    domain = ".".join(parts[-2:])
+    if domain in { "fedcourts.us", "uscourts.gov" }:
+        return map_pacer_to_cl_id(parts[0])
+    return domain_to_cl_id.get(full_domain, full_domain)

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -26,10 +26,12 @@ def map_cl_to_pacer_id(cl_id):
         return cl_id
     return cl_to_pacer_ids.get(cl_id, cl_id)
 
+
 domain_to_cl_id = {
     "sc-us.gov": "scotus",  # Supreme Court of the United States
     "txcourts.gov": "texas",  # All Texas courts
 }
+
 
 def map_domain_to_cl_id(full_domain: str):
     parts = full_domain.split(".")

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -33,24 +33,24 @@ def get_tx_court_id_from_subject(subject: str) -> str | None:
     if not subject.startswith("Automated Case Update from"):
         return None
     return {
-        "First Court of Appeals": "txctapp1",
-        "Second Court of Appeals": "txctapp2",
-        "Third Court of Appeals": "txctapp3",
-        "Fourth Court of Appeals": "txctapp4",
-        "Fifth Court of Appeals": "txctapp5",
-        "Sixth Court of Appeals": "txctapp6",
-        "Seventh Court of Appeals": "txctapp7",
-        "Eighth Court of Appeals": "txctapp8",
-        "Ninth Court of Appeals": "txctapp9",
-        "Tenth Court of Appeals": "txctapp10",
-        "Eleventh Court of Appeals": "txctapp11",
-        "Twelfth Court of Appeals": "txctapp12",
-        "Thirteenth Court of Appeals": "txctapp13",
-        "Fourteenth Court of Appeals": "txctapp14",
-        "Fifteenth Court of Appeals": "txctapp15",
-        "Court of Criminal Appeals": "texcrimapp",
-        "Supreme Court": "tex",
-    }.get(subject[27:])
+        "first court of appeals": "txctapp1",
+        "second court of appeals": "txctapp2",
+        "third court of appeals": "txctapp3",
+        "fourth court of appeals": "txctapp4",
+        "fifth court of appeals": "txctapp5",
+        "sixth court of appeals": "txctapp6",
+        "seventh court of appeals": "txctapp7",
+        "eighth court of appeals": "txctapp8",
+        "ninth court of appeals": "txctapp9",
+        "tenth court of appeals": "txctapp10",
+        "eleventh court of appeals": "txctapp11",
+        "twelfth court of appeals": "txctapp12",
+        "thirteenth court of appeals": "txctapp13",
+        "fourteenth court of appeals": "txctapp14",
+        "fifteenth court of appeals": "txctapp15",
+        "court of criminal appeals": "texcrimapp",
+        "Supreme court": "tex",
+    }.get(subject[27:].lower())
 
 
 domain_to_cl_id = {
@@ -68,7 +68,9 @@ def map_email_to_cl_id(email):
         return map_pacer_to_cl_id(parts[0])
     maybe_cl_id = domain_to_cl_id.get(full_domain, full_domain)
     if maybe_cl_id == "texas":
-        cl_id = get_tx_court_id_from_subject(email["commonHeaders"]["subject"])
+        cl_id = get_tx_court_id_from_subject(
+            email["common_headers"]["subject"]
+        )
     else:
         cl_id = maybe_cl_id
     return cl_id

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -205,6 +205,7 @@ def scotus_event():
         data = json.load(file)
     return data
 
+
 @pytest.fixture()
 def texas_event():
     with open("./events/texas-1.json", encoding="utf-8") as file:

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -318,7 +318,7 @@ def test_scotus_email_request(
         "AUTH_TOKEN": "************************",
     },
 )
-def test_scotus_email_request(
+def test_texas_email_request(
     texas_event,
     requests_mock,  # noqa: F811
 ):

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -125,7 +125,7 @@ def test_get_cl_court_id_using_mapping():
         email = {
             "common_headers": {"from": [f"ecfnotices@{pacer_id}.uscourts.gov"]}
         }
-        result = app.get_cl_court_id(email)
+        result = app.map_email_to_cl_id(email)
         assert result == expected_cl, (
             f"For PACER id '{pacer_id}', expected CL id '{expected_cl}' but "
             f"got '{result}'."
@@ -260,7 +260,7 @@ def test_request_court_field_actual_value(
     requests_mock,  # noqa: F811
 ):
     """Confirm that the court_id in the request uses the right value
-    from map_pacer_to_cl_id"""
+    from map_email_to_cl_id"""
     requests_mock.post(
         "http://host.docker.internal:8000/api/rest/v3/recap-email/",
         json={"mail": {}, "receipt": {}},
@@ -402,7 +402,7 @@ def test_ignore_messages_from_invalid_court_ids(
     validation_domain_failure is sent."""
 
     with mock.patch(
-        "recap_email.app.app.get_cl_court_id", return_value="updates"
+        "recap_email.app.app.map_email_to_cl_id", return_value="updates"
     ):
         requests_mock.post(
             "http://host.docker.internal:8000/api/rest/v3/recap-email/",

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -342,8 +342,8 @@ def test_texas_email_request(
     )
 
     body = json.loads(request.body)
-    assert body.get("court") == "texas", (
-        f"Expected 'texas', but got '{body.get('court')}'"
+    assert body.get("court") == "txctapp1", (
+        f"Expected 'txctapp1', but got '{body.get('court')}'"
     )
 
 


### PR DESCRIPTION
Resolves #30

Adds global constant `CL_ENDPOINT_MAP` in `cl/recap_email/app/app.py` to allow `check_valid_domain` and `get_cl_court_id` to pull from the same source and simplify future additions.

Adds `map_domain_to_cl_id` method in `cl/recap_email/app/pacer.py` to map email domains to CL IDs, using the existing `map_pacer_to_cl_id` method if the domain is `fedcourts.us` or `uscourts.gov`.

Replaces existing usages of `map_pacer_to_cl_id` with `map_domain_to_cl_id`.

**Notes**

This works for now, but if we continue adding more domains we need to route mail for, we should consider rethinking the design of this Lambda. Right now, it makes some assumptions that only make sense for PACER, which make adding routes for other types of email challenging.