### PR TITLE
fix(app): Added missing Texas and SCOTUS env vars to template.yaml

### DIFF
--- a/cl/env.json
+++ b/cl/env.json
@@ -2,7 +2,7 @@
   "RecapEmailFunction": {
     "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",
     "SCOTUS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/scrapers/scotus-email/",
-    "TEXAS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/state/tx/tames/alerts",
+    "TEXAS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/state/tx/tames/alerts/",
     "AUTH_TOKEN": "****************************",
     "SENTRY_DSN": ""
   }

--- a/cl/template.yaml
+++ b/cl/template.yaml
@@ -20,6 +20,8 @@ Resources:
       Environment:
         Variables:
           RECAP_EMAIL_ENDPOINT: https://www.courtlistener.com/api/rest/v3/recap-email/
+          SCOTUS_EMAIL_ENDPOINT: https://www.courtlistener.com/api/rest/v4/scrapers/scotus-email/
+          TEXAS_EMAIL_ENDPOINT: https://www.courtlistener.com/api/rest/v4/state/tx/tames/alerts/
           AUTH_TOKEN: xxxxxxxxxxxxxxxxxxxxxxx
           SENTRY_DSN: ""
       Events:


### PR DESCRIPTION
I ran a local test of this Lambda yesterday and noticed that the `SCOTUS_EMAIL_ENDPOINT` and `TEXAS_EMAIL_ENDPOINT` environment variables were missing from the `template.yaml` file, but they are required for the app to recognize them.

After this is merged I'll be deploying the Lambda to enable Texas `CaseEmail` functionality.