### PR TITLE
fix(app): Ignore SCOTUS/Texas emails from other SES rules

### DIFF
--- a/cl/events/scotus-1.json
+++ b/cl/events/scotus-1.json
@@ -9,7 +9,7 @@
                     "source": "buttons@recap.email",
                     "messageId": "cqoglnefvc8p995tuu8mfh3b77c9sgn4vr940vg1",
                     "destination": [
-                        "user@recap.email"
+                        "user@scotus.recap.email"
                     ],
                     "headersTruncated": false,
                     "headers": [

--- a/cl/events/texas-1.json
+++ b/cl/events/texas-1.json
@@ -7,7 +7,7 @@
         "timestamp": "2019-08-05T21:30:02.028Z",
         "source": "prvs=144d0cba7=noreply-tames@txcourts.gov",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["user@recap.email"],
+        "destination": ["user@texas.recap.email"],
         "headersTruncated": false,
         "headers": [{
           "name": "Return-Path",

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -169,9 +169,7 @@ def destination_matches_subscription(email):
         if len(dest_parts) != 2:
             continue
         dest_domain = dest_parts[1].lower()
-        if dest_domain == required or dest_domain.endswith(
-            f".{required}"
-        ):
+        if dest_domain == required or dest_domain.endswith(f".{required}"):
             return True
     return False
 

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -11,7 +11,11 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError, Timeout
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
-from .pacer import map_email_to_cl_id, sub_domains_to_ignore
+from .pacer import (
+    domain_to_subscription_subdomain,
+    map_email_to_cl_id,
+    sub_domains_to_ignore,
+)
 from .utils import retry  # pylint: disable=import-error
 
 # NOTE - This is necessary for the relative imports.
@@ -128,6 +132,53 @@ def validation_domain_failure(email, receipt, verdict):
     return {
         "statusCode": 424,
         "valid_domain": {"status": "FAILED"},
+        "body": json.dumps(receipt),
+    }
+
+
+def get_source_domain(email):
+    """Return the registrable domain from the email's Return-Path header,
+    or None if no Return-Path is present or parseable.
+    """
+    for email_address in get_ses_email_headers(email, "Return-Path"):
+        parts = parseaddr(email_address)[1].split("@")
+        if len(parts) != 2:
+            continue
+        return ".".join(parts[1].split(".")[-2:]).lower()
+    return None
+
+
+def destination_matches_subscription(email):
+    """Return True if the email should be processed, False if it should be
+    ignored because its source domain requires a specific subscription
+    subdomain (e.g., scotus.recap.email) but the destination does not use it.
+    """
+    source_domain = get_source_domain(email)
+    if source_domain is None:
+        return True
+    required = domain_to_subscription_subdomain.get(source_domain)
+    if required is None:
+        return True
+    for destination in email.get("destination", []):
+        dest_parts = parseaddr(destination)[1].split("@")
+        if len(dest_parts) != 2:
+            return False
+        dest_domain = dest_parts[1].lower()
+        if dest_domain != required and not dest_domain.endswith(
+            f".{required}"
+        ):
+            return False
+    return True
+
+
+def ignore_wrong_subscription(email, receipt):
+    print(
+        f"{get_combined_log_message(email)} ignored — destination does not "
+        f"match the required subscription subdomain for its source domain."
+    )
+    return {
+        "statusCode": 200,
+        "subscription": {"status": "IGNORED"},
         "body": json.dumps(receipt),
     }
 
@@ -272,6 +323,8 @@ def handler(event, context):  # pylint: disable=unused-argument
     # Ignore messages that are not from courts, such as updates.uscourts.gov
     if domain_verdict != "PASS":
         return validation_domain_failure(email, receipt, domain_verdict)
+    if not destination_matches_subscription(email):
+        return ignore_wrong_subscription(email, receipt)
     court_id = map_email_to_cl_id(email)
     if court_id in sub_domains_to_ignore:
         return validation_domain_failure(email, receipt, domain_verdict)

--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -152,6 +152,11 @@ def destination_matches_subscription(email):
     """Return True if the email should be processed, False if it should be
     ignored because its source domain requires a specific subscription
     subdomain (e.g., scotus.recap.email) but the destination does not use it.
+
+    Specifically, if any address in the email's destination list matches the
+    expected destination for the given source domain, return True. Otherwise,
+    return False. This lets us handle potential emails with multiple destinations
+    correctly.
     """
     source_domain = get_source_domain(email)
     if source_domain is None:
@@ -162,13 +167,13 @@ def destination_matches_subscription(email):
     for destination in email.get("destination", []):
         dest_parts = parseaddr(destination)[1].split("@")
         if len(dest_parts) != 2:
-            return False
+            continue
         dest_domain = dest_parts[1].lower()
-        if dest_domain != required and not dest_domain.endswith(
+        if dest_domain == required or dest_domain.endswith(
             f".{required}"
         ):
-            return False
-    return True
+            return True
+    return False
 
 
 def ignore_wrong_subscription(email, receipt):

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -69,6 +69,14 @@ domain_to_cl_id = {
     "txcourts.gov": "texas",  # All Texas courts
 }
 
+# Maps a court source domain to the subscription subdomain that must receive
+# its emails. Emails from these domains that arrive via a different SES rule
+# (e.g., the generic recap.email rule) are ignored to avoid double processing.
+domain_to_subscription_subdomain = {
+    "sc-us.gov": "scotus.recap.email",
+    "txcourts.gov": "texas.recap.email",
+}
+
 
 def map_email_to_cl_id(email):
     """

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -8,6 +8,7 @@ import pytest
 import requests  # noqa: F401
 import requests_mock  # noqa: F401
 from recap_email.app import app  # pylint: disable=import-error
+from recap_email.app.app import destination_matches_subscription
 from recap_email.app.pacer import (  # pylint: disable=import-error
     pacer_to_cl_ids,
 )
@@ -447,6 +448,20 @@ def test_texas_email_ignored_for_wrong_subscription(
     assert response["statusCode"] == 200
     assert response["subscription"]["status"] == "IGNORED"
     assert len(requests_mock.request_history) == 0
+
+
+@mock.patch("recap_email.app.app.get_source_domain")
+def test_destination_list_matches_subscription(mock_get_source_domain):
+    source_domain = "sc-us.gov"
+    mock_get_source_domain.return_value = source_domain
+
+    email = {
+        "destination": [ "bob@test.email", "notifications@scotus.recap.email" ]
+    }
+
+    m = destination_matches_subscription(email)
+
+    assert m == True
 
 
 @mock.patch.dict(

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -456,7 +456,7 @@ def test_destination_list_matches_subscription(mock_get_source_domain):
     mock_get_source_domain.return_value = source_domain
 
     email = {
-        "destination": [ "bob@test.email", "notifications@scotus.recap.email" ]
+        "destination": ["bob@test.email", "notifications@scotus.recap.email"]
     }
 
     m = destination_matches_subscription(email)

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -390,6 +390,68 @@ def test_report_request_for_invalid_court(
 @mock.patch.dict(
     os.environ,
     {
+        "SCOTUS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/scrapers/scotus-email/",  # noqa: E501 pylint: disable=line-too-long
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
+        "AUTH_TOKEN": "************************",
+    },
+)
+def test_scotus_email_ignored_for_wrong_subscription(
+    scotus_event,
+    requests_mock,  # noqa: F811
+):
+    """A SCOTUS email delivered to a plain @recap.email address is ignored to
+    avoid double processing via the generic recap.email SES rule."""
+    scotus_event["Records"][0]["ses"]["mail"]["destination"] = [
+        "user@recap.email"
+    ]
+    requests_mock.register_uri(
+        "POST",
+        re.compile(r".*"),
+        json={"mail": {}, "receipt": {}},
+        status_code=200,
+    )
+
+    response = app.handler(scotus_event, "")
+
+    assert response["statusCode"] == 200
+    assert response["subscription"]["status"] == "IGNORED"
+    assert len(requests_mock.request_history) == 0
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "TEXAS_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v4/email/state/tx/tames/alert",  # noqa: E501 pylint: disable=line-too-long
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
+        "AUTH_TOKEN": "************************",
+    },
+)
+def test_texas_email_ignored_for_wrong_subscription(
+    texas_event,
+    requests_mock,  # noqa: F811
+):
+    """A Texas email delivered to a plain @recap.email address is ignored to
+    avoid double processing via the generic recap.email SES rule."""
+    texas_event["Records"][0]["ses"]["mail"]["destination"] = [
+        "user@recap.email"
+    ]
+    requests_mock.register_uri(
+        "POST",
+        re.compile(r".*"),
+        json={"mail": {}, "receipt": {}},
+        status_code=200,
+    )
+
+    response = app.handler(texas_event, "")
+
+    assert response["statusCode"] == 200
+    assert response["subscription"]["status"] == "IGNORED"
+    assert len(requests_mock.request_history) == 0
+
+
+@mock.patch.dict(
+    os.environ,
+    {
         "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
         "AUTH_TOKEN": "************************",
     },

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -461,7 +461,7 @@ def test_destination_list_matches_subscription(mock_get_source_domain):
 
     m = destination_matches_subscription(email)
 
-    assert m == True
+    assert m
 
 
 @mock.patch.dict(


### PR DESCRIPTION
Verify that the destination subscription subdomain matches the source court domain before routing. Emails from sc-us.gov or txcourts.gov must be sent to a `@scotus.recap.email` or `@texas.recap.email` address respectively or they will be ignored.

Closes #34