### PR TITLE
36 Disambiguate shared court domains using the ECF host in Received headers 

### DIFF
--- a/cl/recap_email/app/app.py
+++ b/cl/recap_email/app/app.py
@@ -237,7 +237,7 @@ def get_cl_endpoint(email):
     delay=10,
     backoff=3,
 )
-def send_to_court_listener(email, receipt):
+def send_to_court_listener(email, receipt, court_id):
     print(f"{get_combined_log_message(email)} sending to Court Listener API.")
     endpoint = get_cl_endpoint(email)
 
@@ -248,7 +248,7 @@ def send_to_court_listener(email, receipt):
             {
                 "mail": email,
                 "receipt": receipt,
-                "court": map_email_to_cl_id(email),
+                "court": court_id,
             }
         ),
         timeout=5,
@@ -331,4 +331,4 @@ def handler(event, context):  # pylint: disable=unused-argument
     court_id = map_email_to_cl_id(email)
     if court_id in sub_domains_to_ignore:
         return validation_domain_failure(email, receipt, domain_verdict)
-    return send_to_court_listener(email, receipt)
+    return send_to_court_listener(email, receipt, court_id)

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -1,4 +1,7 @@
+import re
 from email.utils import parseaddr
+
+import sentry_sdk
 
 pacer_to_cl_ids = {
     # Maps PACER ids to their CL equivalents
@@ -64,6 +67,46 @@ def get_tx_court_id_from_subject(subject: str) -> str:
     return court_map[court_name]
 
 
+# Matches the originating ECF database hostname that courts stamp into the
+# earliest Received headers of every NEF, e.g. "txsbdb.txsb.gtwy.dcn". The
+# "<name>db." prefix is required so generic court mail relays under gtwy.dcn
+# (e.g. "smtp2-i.asbn.gtwy.dcn") don't match.
+ecf_host_re = re.compile(
+    r"\b[a-z0-9]+db\.([a-z0-9]+)\.gtwy\.dcn", re.IGNORECASE
+)
+
+# PACER email subdomains shared by more than one court, mapped to the PACER
+# court ids whose NEFs legitimately originate from that domain. Only these
+# domains may have their From court overridden by the ECF host found
+# in the Received headers.
+shared_domain_courts = {
+    "txs": {"txsd", "txsb"},  # S.D. Tex. district and bankruptcy
+}
+
+
+def get_ecf_host_court(email):
+    """Extract the PACER court id from the originating ECF database hostname
+    in the email's Received headers.
+
+    The last regex match across the concatenated Received headers is the one
+    closest to the originating server, since each relay prepends its header.
+
+    :param email: Object containing email content and metadata.
+
+    :return: The lowercase PACER court id, or None if no ECF database host is
+    present (e.g. non-NEF mail from court staff or mailing lists).
+    """
+    received = " ".join(
+        header["value"]
+        for header in email.get("headers", [])
+        if header["name"] == "Received"
+    )
+    matches = ecf_host_re.findall(received)
+    if not matches:
+        return None
+    return matches[-1].lower()
+
+
 domain_to_cl_id = {
     "sc-us.gov": "scotus",  # Supreme Court of the United States
     "txcourts.gov": "texas",  # All Texas courts
@@ -92,7 +135,23 @@ def map_email_to_cl_id(email):
     parts = full_domain.split(".")
     domain = ".".join(parts[-2:])
     if domain in {"fedcourts.us", "uscourts.gov"}:
-        return map_pacer_to_cl_id(parts[0])
+        pacer_id = parts[0]
+        ecf_court = get_ecf_host_court(email)
+        if ecf_court is not None and ecf_court != pacer_id.lower():
+            if ecf_court in shared_domain_courts.get(pacer_id.lower(), set()):
+                return map_pacer_to_cl_id(ecf_court)
+            message_id = email.get("message_id")
+            error_message = (
+                f"ECF host court mismatch: From-derived court "
+                f"{pacer_id!r} vs ECF host court {ecf_court!r} - "
+                f"message_id: {message_id}"
+            )
+            sentry_sdk.capture_message(
+                error_message,
+                level="error",
+                fingerprint=["ecf-host-court-mismatch"],
+            )
+        return map_pacer_to_cl_id(pacer_id)
     maybe_cl_id = domain_to_cl_id.get(full_domain, full_domain)
     if maybe_cl_id == "texas":
         return get_tx_court_id_from_subject(email["common_headers"]["subject"])

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -10,6 +10,7 @@ import requests_mock  # noqa: F401
 from recap_email.app import app  # pylint: disable=import-error
 from recap_email.app.app import destination_matches_subscription
 from recap_email.app.pacer import (  # pylint: disable=import-error
+    get_ecf_host_court,
     pacer_to_cl_ids,
 )
 
@@ -131,6 +132,98 @@ def test_get_cl_court_id_using_mapping():
             f"For PACER id '{pacer_id}', expected CL id '{expected_cl}' but "
             f"got '{result}'."
         )
+
+
+def make_court_email(from_addr, received_hosts):
+    """Build a minimal email object with Received headers listed from the
+    latest relay down to the originating server, as in a real message."""
+    return {
+        "message_id": "test-ecf-host-message-id",
+        "common_headers": {"from": [from_addr]},
+        "headers": [
+            {
+                "name": "Received",
+                "value": (
+                    f"from unknown (HELO {host}) ([156.119.56.176]) by "
+                    "icmecf202.gtwy.uscourts.gov with ESMTP; "
+                    "28 Jun 2021 18:51:10 +0000"
+                ),
+            }
+            for host in received_hosts
+        ],
+    }
+
+
+def test_ecf_host_overrides_shared_domain_bankruptcy():
+    """A txsb NEF arrives from the shared txs.uscourts.gov domain; the ECF
+    database host in the Received headers must reassign it to txsb."""
+    email = make_court_email(
+        "BKECF_LiveDB@txs.uscourts.gov",
+        ["relay1.uscourts.gov", "txsbdb.txsb.gtwy.dcn"],
+    )
+    assert app.map_email_to_cl_id(email) == "txsb"
+
+
+def test_ecf_host_confirms_shared_domain_district():
+    """A txsd NEF from the shared txs.uscourts.gov domain must still map to
+    txsd (the majority case for the shared domain)."""
+    email = make_court_email(
+        "ecf_txsd@txs.uscourts.gov",
+        ["relay1.uscourts.gov", "txsddb.txsd.gtwy.dcn"],
+    )
+    assert app.map_email_to_cl_id(email) == "txsd"
+
+
+def test_ecf_host_agreement_keeps_court():
+    """When the From domain and the ECF host agree, behavior is unchanged."""
+    email = make_court_email(
+        "cacd_ecfmail@cacd.uscourts.gov",
+        ["relay1.uscourts.gov", "cacddb.cacd.gtwy.dcn"],
+    )
+    assert app.map_email_to_cl_id(email) == "cacd"
+
+
+def test_ecf_host_mismatch_on_non_shared_domain_logs_error():
+    """A disagreement on a domain outside the shared-domain set keeps the
+    From-derived court and reports the mismatch to Sentry."""
+    email = make_court_email(
+        "cacd_ecfmail@cacd.uscourts.gov",
+        ["relay1.uscourts.gov", "nysbdb.nysb.gtwy.dcn"],
+    )
+    with mock.patch(
+        "recap_email.app.pacer.sentry_sdk.capture_message"
+    ) as mock_sentry_capture:
+        assert app.map_email_to_cl_id(email) == "cacd"
+    expected_error = (
+        "ECF host court mismatch: From-derived court 'cacd' vs ECF host "
+        "court 'nysb' - message_id: test-ecf-host-message-id"
+    )
+    mock_sentry_capture.assert_called_with(
+        expected_error,
+        level="error",
+        fingerprint=["ecf-host-court-mismatch"],
+    )
+
+
+def test_ecf_host_ignores_generic_gtwy_relays():
+    """Generic court mail relays under gtwy.dcn are not ECF database hosts
+    and must not match, so behavior stays unchanged without an ECF host."""
+    email = make_court_email(
+        "BKECF_LiveDB@txs.uscourts.gov",
+        ["relay1.uscourts.gov", "smtp2-i.asbn.gtwy.dcn"],
+    )
+    assert get_ecf_host_court(email) is None
+    assert app.map_email_to_cl_id(email) == "txsd"
+
+
+def test_ecf_host_uses_earliest_received_header():
+    """The last match across the Received headers (closest to the
+    originating server) wins over hosts stamped by later relays."""
+    email = make_court_email(
+        "BKECF_LiveDB@txs.uscourts.gov",
+        ["otherdb.other.gtwy.dcn", "txsbdb.txsb.gtwy.dcn"],
+    )
+    assert get_ecf_host_court(email) == "txsb"
 
 
 @pytest.fixture()
@@ -275,6 +368,46 @@ def test_request_court_field_actual_value(
     body = json.loads(request.body)
     assert body.get("court") == "mowd", (
         f"Expected 'mowd', but got '{body.get('court')}'"
+    )
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "RECAP_EMAIL_ENDPOINT": "http://host.docker.internal:8000/api/rest/v3/recap-email/",  # noqa: E501 pylint: disable=line-too-long
+        "AUTH_TOKEN": "************************",
+    },
+)
+def test_request_court_field_uses_ecf_host_for_shared_domain(
+    pacer_event_two,
+    requests_mock,  # noqa: F811
+):
+    """A bankruptcy NEF from the shared txs.uscourts.gov domain must be
+    posted with the ECF-host court (txsb), not the district default."""
+    mail = pacer_event_two["Records"][0]["ses"]["mail"]
+    mail["commonHeaders"]["from"] = ["<BKECF_LiveDB@txs.uscourts.gov>"]
+    mail["headers"].append(
+        {
+            "name": "Received",
+            "value": (
+                "from txsbdb.txsb.gtwy.dcn (localhost.localdomain "
+                "[127.0.0.1]) by txsbdb.txsb.gtwy.dcn with ESMTP; "
+                "Mon, 28 Jun 2021 13:51:08 -0500"
+            ),
+        }
+    )
+    requests_mock.post(
+        "http://host.docker.internal:8000/api/rest/v3/recap-email/",
+        json={"mail": {}, "receipt": {}},
+    )
+
+    response = app.handler(pacer_event_two, "")
+    assert response["statusCode"] == 200
+
+    request = requests_mock.request_history[0]
+    body = json.loads(request.body)
+    assert body.get("court") == "txsb", (
+        f"Expected 'txsb', but got '{body.get('court')}'"
     )
 
 


### PR DESCRIPTION
Fixes: #36 

Some court email domains are shared by a district court and its sibling bankruptcy court, so the From header alone cannot identify the court:

  - txs.uscourts.gov is used by both txsd (S.D. Tex. district) and txsb (S.D. Tex. bankruptcy). Real txsb NEFs arrive with From: `@txs.uscourts.gov.`

Today the lambda maps these domains unconditionally (txs → txsd), so bankruptcy NEFs are attributed to the district court. CourtListener then parses them with juriscraper's district-court parsing logic that fails.


To solve this issue for now, we'll use a different header (Received) to disambiguate the court ID e.g:

`Received: from unknown (HELO txsbdb.txsb.gtwy.dcn) ([156.119.56.176]) by icmecf202.gtwy.uscourts.gov with ESMTP;
`
From this header, we extract the last match of `\b[a-z0-9]+db\.([a-z0-9]+)\.gtwy\.dcn` across the concatenated Received headers. This pattern matches only ECF database hosts and rejects generic court mail relays (for example, smtp2-i.asbn.gtwy.dcn) that also reside under gtwy.dcn.

To confirm this I validated against 5,594 real production notifications:
  - 5,345 of 5,594 messages with a court From domain: ECF host agrees exactly with From.
  - 223 mismatches. All right corrections of the shared domains: txs → txsd. No false mismatches.
  - 26 messages had no ECF host, and none were real NEFs (updates.uscourts.gov mailings, court staff emailing manually, 2 spoofed emails via emkei.cz that the strict regex correctly refuses to match).

Other headers don't work: `To:` is missing a court domain in ~11% of messages (and sometimes wrong); Return-Path, envelope-from, Received-SPF, and Message-Id all reuse the same ambiguous domain as From.


The  original behavior is preserved for all courts; only known shared domains can be overridden, and every disagreement is logged so new shared domains surface on their own:

  1. The court is still derived from the From domain (primary).
  2. The ECF-host court is always also extracted from the Received headers and compared.
  3. On disagreement:
    - If the From-derived subdomain is in shared_domain_courts (txs → {txsd, txsb}) and the ECF-host court is one of that domain's legitimate siblings, use the ECF-host court.
    - Otherwise, keep the From-derived court and report the mismatch to Sentry (fingerprint ecf-host-court-mismatch) with both values and the message ID, so the set can be reviewed and extended.
  4. If no ECF host is found, behavior is unchanged (the normal case for non-NEF emails).

Also, send_to_court_listener() now receives the court id computed once in handler() instead of recomputing it, so mismatches are logged once per email.