### PR TITLE
fix(app): Compare mapped CL courts to avoid false ECF host mismatches

### DIFF
--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -16,6 +16,8 @@ pacer_to_cl_ids = {
     "id": "idd",  # District Court, D. Idaho
 }
 
+# Notice that MIWD (uppercase) was found not to be a NEF. This differentiates it
+# from miwd (lowercase), which is related to actual NEFs.
 sub_domains_to_ignore = ["usdoj", "law", "psc", "updates", "MIWD"]
 
 # Reverse dict of pacer_to_cl_ids
@@ -137,16 +139,17 @@ def map_email_to_cl_id(email):
     if domain in {"fedcourts.us", "uscourts.gov"}:
         pacer_id = parts[0]
         pacer_id_lower = pacer_id.lower()
+        from_court = map_pacer_to_cl_id(pacer_id)
+        from_court_lower = map_pacer_to_cl_id(pacer_id_lower)
         ecf_court = get_ecf_host_court(email)
+        ecf_cl_court = map_pacer_to_cl_id(ecf_court)
         # Compare mapped CL courts, not raw subdomains: courts like gas or
         # mow use a From subdomain that differs from their ECF host court
         # (gasddb.gasd.gtwy.dcn) but both resolve to the same CL court in
         # map_pacer_to_cl_id.
-        if ecf_court is not None and map_pacer_to_cl_id(
-            ecf_court
-        ) != map_pacer_to_cl_id(pacer_id_lower):
+        if ecf_court is not None and ecf_cl_court != from_court_lower:
             if ecf_court in shared_domain_courts.get(pacer_id_lower, set()):
-                return map_pacer_to_cl_id(ecf_court)
+                return ecf_cl_court
             message_id = email.get("message_id")
             error_message = (
                 f"ECF host court mismatch: From-derived court "
@@ -158,7 +161,7 @@ def map_email_to_cl_id(email):
                 level="error",
                 fingerprint=["ecf-host-court-mismatch"],
             )
-        return map_pacer_to_cl_id(pacer_id)
+        return from_court
     maybe_cl_id = domain_to_cl_id.get(full_domain, full_domain)
     if maybe_cl_id == "texas":
         return get_tx_court_id_from_subject(email["common_headers"]["subject"])

--- a/cl/recap_email/app/pacer.py
+++ b/cl/recap_email/app/pacer.py
@@ -136,9 +136,16 @@ def map_email_to_cl_id(email):
     domain = ".".join(parts[-2:])
     if domain in {"fedcourts.us", "uscourts.gov"}:
         pacer_id = parts[0]
+        pacer_id_lower = pacer_id.lower()
         ecf_court = get_ecf_host_court(email)
-        if ecf_court is not None and ecf_court != pacer_id.lower():
-            if ecf_court in shared_domain_courts.get(pacer_id.lower(), set()):
+        # Compare mapped CL courts, not raw subdomains: courts like gas or
+        # mow use a From subdomain that differs from their ECF host court
+        # (gasddb.gasd.gtwy.dcn) but both resolve to the same CL court in
+        # map_pacer_to_cl_id.
+        if ecf_court is not None and map_pacer_to_cl_id(
+            ecf_court
+        ) != map_pacer_to_cl_id(pacer_id_lower):
+            if ecf_court in shared_domain_courts.get(pacer_id_lower, set()):
                 return map_pacer_to_cl_id(ecf_court)
             message_id = email.get("message_id")
             error_message = (

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -185,8 +185,10 @@ def test_ecf_host_agreement_keeps_court():
 
 def test_ecf_host_agreement_via_pacer_mapping_is_not_a_mismatch():
     """Courts like gas or mow use a From subdomain that differs from their
-    ECF host court (gasddb.gasd.gtwy.dcn) but both resolve to the same CL
-    court via pacer_to_cl_ids, so no mismatch may be reported to Sentry."""
+    ECF host court (gasddb.gasd.gtwy.dcn), and courts like neb use an ECF
+    host that differs from their CL id (nebdb.neb.gtwy.dcn vs nebraskab),
+    but both sides resolve to the same CL court via pacer_to_cl_ids, so no
+    mismatch may be reported to Sentry."""
     emails = [
         ("efile_support@gas.uscourts.gov", "gasddb.gasd.gtwy.dcn", "gasd"),
         (
@@ -194,6 +196,7 @@ def test_ecf_host_agreement_via_pacer_mapping_is_not_a_mismatch():
             "mowddb.mowd.gtwy.dcn",
             "mowd",
         ),
+        ("neb_bkecf@neb.uscourts.gov", "nebdb.neb.gtwy.dcn", "nebraskab"),
     ]
     for from_addr, ecf_host, expected_court in emails:
         email = make_court_email(from_addr, ["relay1.uscourts.gov", ecf_host])

--- a/cl/tests/unit/test_recap_email_handler.py
+++ b/cl/tests/unit/test_recap_email_handler.py
@@ -183,6 +183,27 @@ def test_ecf_host_agreement_keeps_court():
     assert app.map_email_to_cl_id(email) == "cacd"
 
 
+def test_ecf_host_agreement_via_pacer_mapping_is_not_a_mismatch():
+    """Courts like gas or mow use a From subdomain that differs from their
+    ECF host court (gasddb.gasd.gtwy.dcn) but both resolve to the same CL
+    court via pacer_to_cl_ids, so no mismatch may be reported to Sentry."""
+    emails = [
+        ("efile_support@gas.uscourts.gov", "gasddb.gasd.gtwy.dcn", "gasd"),
+        (
+            "ecfMOW.notification@mow.uscourts.gov",
+            "mowddb.mowd.gtwy.dcn",
+            "mowd",
+        ),
+    ]
+    for from_addr, ecf_host, expected_court in emails:
+        email = make_court_email(from_addr, ["relay1.uscourts.gov", ecf_host])
+        with mock.patch(
+            "recap_email.app.pacer.sentry_sdk.capture_message"
+        ) as mock_sentry_capture:
+            assert app.map_email_to_cl_id(email) == expected_court
+        mock_sentry_capture.assert_not_called()
+
+
 def test_ecf_host_mismatch_on_non_shared_domain_logs_error():
     """A disagreement on a domain outside the shared-domain set keeps the
     From-derived court and reports the mismatch to Sentry."""


### PR DESCRIPTION
## Problem

Follow-up to #37. The `ecf-host-court-mismatch` Sentry [issue](https://freelawproject.sentry.io/issues/7596204163/events/25d097c5b75f4220b951ad8bf2cfa8eb/) was a false positive for a court whose two identifiers legitimately differ:

- **gas**: `From: efile_support@gas.uscourts.gov` and `Received: ... gasddb.gasd.gtwy.dcn`  `gas` vs `gasd`. Same for **mow**.

Every notification from these courts was reported to Sentry as a mismatch, generating constant noise.

## Fix

Compare the **mapped CL courts** instead of the raw subdomains both sides of the comparison go through `map_pacer_to_cl_id`:

```python
if ecf_court is not None and map_pacer_to_cl_id(
    ecf_court
) != map_pacer_to_cl_id(pacer_id_lower):
```

- `gas` vs `gasd` → both map to `gasd` → silent. Same for `mow`/`mowd`, `neb`/`nebraskab`, and other remapped courts (`azb` → `arb`, `nysb-mega` → `nysb`).
- A genuine sibling-court NEF (e.g. a future `mowb` or `gasb`) still maps to a different CL court and fires the Sentry error.
- txs behavior is unchanged: `txsb` still overrides via the allowlist; `txsd` matches via the mapping.